### PR TITLE
Update FirebaseToken.php

### DIFF
--- a/FirebaseToken.php
+++ b/FirebaseToken.php
@@ -77,7 +77,7 @@ class Services_FirebaseTokenGenerator
             throw new Exception($funcName + ": data is empty and no options are set.  This token will have no effect on Firebase.");
         }
 
-        $claims = array("admin" => true);
+        $claims = array("admin" => false);
         if (is_array($options)) {
             $claims = $this->_processOptions($options);
         }

--- a/FirebaseToken.php
+++ b/FirebaseToken.php
@@ -77,7 +77,7 @@ class Services_FirebaseTokenGenerator
             throw new Exception($funcName + ": data is empty and no options are set.  This token will have no effect on Firebase.");
         }
 
-        $claims = array();
+        $claims = array("admin" => true);
         if (is_array($options)) {
             $claims = $this->_processOptions($options);
         }


### PR DESCRIPTION
when no option is given, the line below may raise compiler error (depending on the errorlevel set) because $claims["admin"] is undefined:

$this->_validateData($funcName, $data, ($claims["admin"] == true));

I changed it so that it defaults to full access as I guess it is the wanted default behavior.
