### PR TITLE
Concatenation and tests

### DIFF
--- a/FirebaseToken.php
+++ b/FirebaseToken.php
@@ -175,7 +175,8 @@ class Services_FirebaseTokenGenerator
         $messages = array(
             JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
             JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
-            JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON'
+            JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
+            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded'
         );
         throw new UnexpectedValueException(isset($messages[$errno])
             ? $messages[$errno]

--- a/FirebaseToken.php
+++ b/FirebaseToken.php
@@ -74,7 +74,7 @@ class Services_FirebaseTokenGenerator
         } else if ($json === "null" && $data !== null) {
             throw new UnexpectedValueException("Data is not valid JSON");
         } else if (empty($data) && empty($options)) {
-            throw new Exception($funcName + ": data is empty and no options are set.  This token will have no effect on Firebase.");
+            throw new Exception($funcName . ": data is empty and no options are set.  This token will have no effect on Firebase.");
         }
 
         $claims = array();
@@ -90,7 +90,7 @@ class Services_FirebaseTokenGenerator
 
         $token = JWT::encode($claims, $this->secret, "HS256");
         if (strlen($token) > 1024) {
-            throw new Exception($funcName + ": generated token is too large.  Token cannot be larger than 1024 bytes.");
+            throw new Exception($funcName . ": generated token is too large.  Token cannot be larger than 1024 bytes.");
         }
         return $token;
     }
@@ -127,19 +127,19 @@ class Services_FirebaseTokenGenerator
                                 $claims[$code] = $value->getTimestamp();
                             } else {
                                 throw new UnexpectedValueException(
-                                    "Provided " + $key +
+                                    "Provided " . $key .
                                     " option is not a DateTime object");
                             }
                             break;
                         default:
                             throw new UnexpectedValueException(
-                                "Provided " + $key +
-                                " option is invalid " + $value);
+                                "Provided " . $key .
+                                " option is invalid " . $value);
                     }
                     break;
                 default:
                     throw new UnexpectedValueException(
-                        "Invalid key " + $key + " provided in options");
+                        "Invalid key " . $key . " provided in options");
             }
         }
         return $claims;
@@ -154,13 +154,13 @@ class Services_FirebaseTokenGenerator
      */
      private static function _validateData($funcName, $data, $isAdminToken) {
         if (!is_null($data) && !is_array($data)) {
-            throw new Exception($funcName + ": data must be null or an associative array of token data.");
+            throw new Exception($funcName . ": data must be null or an associative array of token data.");
         }
         $containsUID = (is_array($data) && array_key_exists("uid", $data));
         if ((!$containsUID && !$isAdminToken) || ($containsUID && !is_string($data["uid"]))) {
-            throw new Exception($funcName + ": data must contain a \"uid\" key that must be a string.");
+            throw new Exception($funcName . ": data must contain a \"uid\" key that must be a string.");
         } else if ($containsUID && (strlen($data["uid"]) > 256)) {
-            throw new Exception($funcName + ": data must contain a \"uid\" key that must not be longer than 256 bytes.");
+            throw new Exception($funcName . ": data must contain a \"uid\" key that must not be longer than 256 bytes.");
         }
     }
 

--- a/tests/FirebaseTokenTest.php
+++ b/tests/FirebaseTokenTest.php
@@ -126,6 +126,13 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
     $this->setExpectedException("Exception", "Services_FirebaseTokenGenerator->createToken: data is empty and no options are set.  This token will have no effect on Firebase.");
     $tokenGen->createToken(null);
   }
+
+  function testMalformedDataThrowsException() {
+    $key = "barfoo";
+    $tokenGen = new Services_FirebaseTokenGenerator($key);
+    $this->setExpectedException("UnexpectedValueException", "Malformed UTF-8 characters, possibly incorrectly encoded");
+    $tokenGen->createToken("\xB1\x31");
+  }
 }
 
 ?>

--- a/tests/FirebaseTokenTest.php
+++ b/tests/FirebaseTokenTest.php
@@ -7,8 +7,8 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
     $key = "0014ae3b1ded44de9d9f6fc60dfd1c64";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
     $token = $tokenGen->createToken(array("foo" => "bar", "baz" => "boo", "uid" => "blah"));
-    
-    $data = JWT::decode($token, $key);
+
+    $data = JWT::decode($token, $key, array('HS256'));
     $this->assertEquals("bar", $data->d->foo);
     $this->assertEquals("boo", $data->d->baz);
     $this->assertInternalType("integer", $data->iat);
@@ -18,8 +18,8 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
     $key = "foobar";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
     $token = $tokenGen->createToken(null, array("admin" => true, "debug" => true));
-    
-    $data = JWT::decode($token, $key);
+
+    $data = JWT::decode($token, $key, array('HS256'));
     $this->assertTrue($data->admin);
     $this->assertTrue($data->debug);
   }
@@ -34,8 +34,8 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
     $tokenGen = new Services_FirebaseTokenGenerator($key);
     $expires = time() + 1000;
     $token = $tokenGen->createToken(array("uid" => "blah"), array("expires" => $expires));
-    
-    $data = JWT::decode($token, $key);
+
+    $data = JWT::decode($token, $key, array('HS256'));
     $this->assertEquals($expires, $data->exp);
   }
 
@@ -44,8 +44,8 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
     $tokenGen = new Services_FirebaseTokenGenerator($key);
     $notBefore = new DateTime("now", new DateTimeZone('America/Los_Angeles'));
     $token = $tokenGen->createToken(array("uid" => "blah"), array("notBefore" => $notBefore));
-    
-    $data = JWT::decode($token, $key);
+
+    $data = JWT::decode($token, $key, array('HS256'));
     $this->assertEquals($notBefore->getTimestamp(), $data->nbf);
   }
 

--- a/tests/FirebaseTokenTest.php
+++ b/tests/FirebaseTokenTest.php
@@ -119,6 +119,13 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
     $this->setExpectedException("Exception");
     $token = $tokenGen->createToken("foo", array("admin" => true));
   }
+
+  function testEmptyDataAndNoOptionsThrowsException() {
+    $key = "barfoo";
+    $tokenGen = new Services_FirebaseTokenGenerator($key);
+    $this->setExpectedException("Exception", "Services_FirebaseTokenGenerator->createToken: data is empty and no options are set.  This token will have no effect on Firebase.");
+    $tokenGen->createToken(null);
+  }
 }
 
 ?>

--- a/tests/FirebaseTokenTest.php
+++ b/tests/FirebaseTokenTest.php
@@ -25,7 +25,7 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
   }
 
   function testMalformedKeyThrowsException() {
-    $this->setExpectedException("UnexpectedValueException");
+    $this->setExpectedException("UnexpectedValueException", 'Invalid secret provided');
     $tokenGen = new Services_FirebaseTokenGenerator(1234567890);
   }
 
@@ -52,14 +52,14 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
   function testNoUID() {
     $key = "barfoo";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
-    $this->setExpectedException("Exception");
+    $this->setExpectedException("Exception", 'Services_FirebaseTokenGenerator->createToken: data must contain a "uid" key that must be a string.');
     $token = $tokenGen->createToken(array("blah" => 5));
   }
 
   function testInvalidUID() {
     $key = "barfoo";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
-    $this->setExpectedException("Exception");
+    $this->setExpectedException("Exception", 'Services_FirebaseTokenGenerator->createToken: data must contain a "uid" key that must be a string.');
     $token = $tokenGen->createToken(array("uid" => 5, "blah" => 5));
   }
 
@@ -73,7 +73,7 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
   function testUIDTooLong() {
     $key = "barfoo";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
-    $this->setExpectedException("Exception");
+    $this->setExpectedException("Exception", 'Services_FirebaseTokenGenerator->createToken: data must contain a "uid" key that must not be longer than 256 bytes.');
     //length:                                               10        20        30        40        50        60        70        80        90       100       110       120       130       140       150       160       170       180       190       200       210       220       230       240       250    257
     $token = $tokenGen->createToken(array("uid" => "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"));
   }
@@ -87,7 +87,7 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
   function testTokenTooLong() {
     $key = "barfoo";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
-    $this->setExpectedException("Exception");
+    $this->setExpectedException("Exception", "Services_FirebaseTokenGenerator->createToken: generated token is too large.  Token cannot be larger than 1024 bytes.");
     $token = $tokenGen->createToken(array("uid" => "blah", "longVar" => "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345612345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456"));
   }
 
@@ -102,21 +102,21 @@ class FirebaseTokenTest extends PHPUnit_Framework_TestCase {
   function testInvalidUIDWithAdmin1() {
     $key = "barfoo";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
-    $this->setExpectedException("Exception");
+    $this->setExpectedException("Exception", 'Services_FirebaseTokenGenerator->createToken: data must contain a "uid" key that must be a string.');
     $token = $tokenGen->createToken(array("uid" => 1), array("admin" => true));
   }
 
   function testInvalidUIDWithAdmin2() {
     $key = "barfoo";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
-    $this->setExpectedException("Exception");
+    $this->setExpectedException("Exception", 'Services_FirebaseTokenGenerator->createToken: data must contain a "uid" key that must be a string.');
     $token = $tokenGen->createToken(array("uid" => null), array("admin" => true));
   }
 
   function testInvalidUIDWithAdmin3() {
     $key = "barfoo";
     $tokenGen = new Services_FirebaseTokenGenerator($key);
-    $this->setExpectedException("Exception");
+    $this->setExpectedException("Exception", "Services_FirebaseTokenGenerator->createToken: data must be null or an associative array of token data.");
     $token = $tokenGen->createToken("foo", array("admin" => true));
   }
 


### PR DESCRIPTION
Greetings!

This PR implements the concatenation changes from #13 and adds the tests for the exception messages to prove that the changed concatenation still works as expected.

Also, it includes some changes that are required to make the tests work again (without the third "allowed algorithms" parameter, the `JWT::decode()` calls would fail).

Cheers!
:octocat: Jérôme
