### PR TITLE
Add support URL and branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
             "role": "Developer"
         }
     ],
+    "support": {
+        "issues": "https://github.com/firebase/firebase-token-generator-php/issues"
+    },
     "license": "MIT",
     "require": {
         "php": ">=5.4",
@@ -33,5 +36,10 @@
             "Firebase\\Token\\Tests\\": "tests"
         }
     },
-    "target-dir": "Firebase/token-generator"
+    "target-dir": "Firebase/token-generator",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a link to the Github issues page and a branch alias to the `composer.json` file to be displayed on the generator's Packagist page.

:octocat: 
- Jérôme

PS: The latest 2.1.0 release hasn't yet shown up on packagist - is this a current issue with Packagist, or isn't the web hook set up to automatically update the page?
