### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "firebase/php-jwt": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6.0"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/tests/FirebaseTokenTest.php
+++ b/tests/FirebaseTokenTest.php
@@ -11,11 +11,12 @@ namespace Firebase\Token\Tests;
 
 use Firebase\JWT\JWT;
 use Firebase\Token\TokenGenerator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for the Legacy \Services_FirebaseTokenGenerator class.
  */
-class FirebaseTokenTest extends \PHPUnit_Framework_TestCase
+class FirebaseTokenTest extends TestCase
 {
     /**
      * @var TokenGenerator

--- a/tests/TokenGeneratorTest.php
+++ b/tests/TokenGeneratorTest.php
@@ -11,8 +11,9 @@ namespace Firebase\Token\Tests;
 
 use Firebase\JWT\JWT;
 use Firebase\Token\TokenGenerator;
+use PHPUnit\Framework\TestCase;
 
-class TokenGeneratorTest extends \PHPUnit_Framework_TestCase
+class TokenGeneratorTest extends TestCase
 {
     /**
      * @var \Firebase\Token\TokenGenerator


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).