### PR TITLE
Correct missing requirement for mbstring extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4",
+        "ext-mbstring": "*",
         "firebase/php-jwt": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
The TokenGenerator class uses mb_strlen(), so errors will occur if PHP doesn't have the optional mbstring extension installed.